### PR TITLE
fix to SW for auth requests

### DIFF
--- a/packages/client/public/sw.js
+++ b/packages/client/public/sw.js
@@ -67,6 +67,10 @@ const putInCache = async (request, response) => {
 }
 
 const cacheFirst = async ({ request, fallbackUrl }) => {
+  if (request.cache === 'no-cache') {
+    return await fetch(request)
+  }
+
   const responseFromCache = await caches.match(request)
   if (responseFromCache) {
     return responseFromCache

--- a/packages/client/src/utils/rest-api/auth-api.ts
+++ b/packages/client/src/utils/rest-api/auth-api.ts
@@ -14,6 +14,7 @@ export async function getUser(): Promise<UserWithRole> {
   // Стало /user
   return await request(BASE_SERVER_URL, USER_API_URL, {
     method: FetchMethods.GET,
+    noCached: true,
   })
 }
 
@@ -21,6 +22,7 @@ export async function signIn(data: UserSignIn): Promise<void> {
   return await request(BASE_YA_URL, `${AUTH_API_URL}${AuthApiPaths.SIGN_IN}`, {
     method: FetchMethods.POST,
     data,
+    noCached: true,
   })
 }
 
@@ -28,11 +30,13 @@ export async function signUp(data: UserSignUp): Promise<{ id: number }> {
   return await request(BASE_YA_URL, `${AUTH_API_URL}${AuthApiPaths.SIGN_UP}`, {
     method: FetchMethods.POST,
     data,
+    noCached: true,
   })
 }
 
 export async function logout(): Promise<void> {
   return await request(BASE_YA_URL, `${AUTH_API_URL}${AuthApiPaths.LOGOUT}`, {
     method: FetchMethods.POST,
+    noCached: true,
   })
 }

--- a/packages/client/src/utils/rest-api/base-request.ts
+++ b/packages/client/src/utils/rest-api/base-request.ts
@@ -10,6 +10,7 @@ export interface RequestInput {
   method?: FetchMethods
   headers?: Record<string, string>
   data?: Record<string, unknown> | FormData
+  noCached?: boolean
 }
 
 export function request<T>(
@@ -17,13 +18,18 @@ export function request<T>(
   endpoint: string,
   options: RequestInput
 ): Promise<T> {
-  const { method = FetchMethods.GET, headers = {}, data } = options
+  const { method = FetchMethods.GET, headers = {}, data, noCached } = options
 
   if (!('Content-Type' in headers) && !(data instanceof FormData)) {
     headers['Content-Type'] = 'application/json'
   }
 
-  const config: RequestInit = { method, headers, credentials: 'include' }
+  const config: RequestInit = {
+    method,
+    headers,
+    credentials: 'include',
+    cache: noCached ? 'no-cache' : 'default',
+  }
 
   if (method !== FetchMethods.GET && data) {
     config.body = data instanceof FormData ? data : JSON.stringify(data)

--- a/packages/client/src/utils/rest-api/oauth-api.ts
+++ b/packages/client/src/utils/rest-api/oauth-api.ts
@@ -15,6 +15,7 @@ export async function getServiceId(
     `${OAUTH_API_URL}${OAUTH_SERVICE_ID}?redirect_uri=${redirectUri}`,
     {
       method: FetchMethods.GET,
+      noCached: true,
     }
   )
 }


### PR DESCRIPTION
Для запросов добавлена опция **noCached**, которая отменяет для запроса кэширование в Service Worker.
Данная опция поставлена для всех запросов аутентификации.
Стратегия сервис воркера осталась та же, CacheFirst.