### PR TITLE
KVA-42 Sprunt 7 leaderboard redux

### DIFF
--- a/packages/client/src/components/Forum/CommentHeaderAndMessage/CommentHeaderAndMessage.tsx
+++ b/packages/client/src/components/Forum/CommentHeaderAndMessage/CommentHeaderAndMessage.tsx
@@ -10,7 +10,7 @@ interface CommentHeaderAndMessageProps {
   avatarPath?: string | null
   displayName?: string | null
   htmlMessage?: string | null
-  messageDate: string
+  messageDate: number
 }
 
 export const CommentHeaderAndMessage: FC<CommentHeaderAndMessageProps> = ({

--- a/packages/client/src/components/Forum/ForumTopic.tsx
+++ b/packages/client/src/components/Forum/ForumTopic.tsx
@@ -17,6 +17,7 @@ export const ForumTopic: FC<IForumTopic & { index: number }> = ({
   id,
   name,
   createdAt,
+  updatedAt,
   categoryId,
   index,
 }) => {
@@ -53,7 +54,7 @@ export const ForumTopic: FC<IForumTopic & { index: number }> = ({
       dispatch(
         onGetForumTopics({
           categoryId,
-          offset: index + 1,
+          updatedAt,
           search: searchQuery || '',
         })
       )

--- a/packages/client/src/components/LeaderboardTable/LeaderboardTable.tsx
+++ b/packages/client/src/components/LeaderboardTable/LeaderboardTable.tsx
@@ -51,23 +51,25 @@ export const LeaderboardTable: FC = () => {
         <Loader />
       ) : errorMessage ? (
         <strong>{errorMessage}</strong>
-      ) : !leaderboardUsers || leaderboardUsers.length === 0 ? (
+      ) : totalPlayers === 0 ? (
         <p style={{ textAlign: 'center' }}>Нет данных</p>
       ) : (
-        <div className={styles.list_wrapper}>
-          <ul className={styles.list}>
-            {leaderboardUsers.map((user, idx) => (
-              <LeaderboardItem
-                key={user.id}
-                ordinal={offset + idx + 1}
-                user={user}
-              />
-            ))}
-          </ul>
-          {totalPages > 1 && (
-            <PageLinks currentPage={currentPage} maxPage={totalPages} />
-          )}
-        </div>
+        !isNaN(offset) && (
+          <div className={styles.list_wrapper}>
+            <ul className={styles.list}>
+              {leaderboardUsers?.map((user, idx) => (
+                <LeaderboardItem
+                  key={user.id}
+                  ordinal={offset + idx + 1}
+                  user={user}
+                />
+              ))}
+            </ul>
+            {totalPages > 1 && (
+              <PageLinks currentPage={currentPage} maxPage={totalPages} />
+            )}
+          </div>
+        )
       )}
     </div>
   )

--- a/packages/client/src/main.tsx
+++ b/packages/client/src/main.tsx
@@ -10,6 +10,8 @@ import { UserRepository } from './store/repositories/UserRepository'
 import { createStore } from './store/store'
 import { ForumService } from './store/services/ForumService'
 import { ForumRepository } from './store/repositories/ForumRepository'
+import { LeaderboardService } from './store/services/LeaderboadService'
+import { LeaderboardRepository } from './store/repositories/LeaderboardRepository'
 
 const startServiceWorker = () => {
   if ('serviceWorker' in navigator) {
@@ -33,7 +35,8 @@ startServiceWorker()
 
 const service = new ThunkService(
   new UserService(new UserRepository()),
-  new ForumService(new ForumRepository())
+  new ForumService(new ForumRepository()),
+  new LeaderboardService(new LeaderboardRepository())
 )
 
 const preloadedState = window.__PRELOADED_STATE__

--- a/packages/client/src/router/index.tsx
+++ b/packages/client/src/router/index.tsx
@@ -20,7 +20,11 @@ import {
   onGetForumComments,
   onGetForumTopics,
 } from '../store/thunks/forum-thunk'
-import { COMMENTS_LOAD_LIMIT } from '../utils/const-variables/api'
+import {
+  COMMENTS_LOAD_LIMIT,
+  LEADERBOARD_LOAD_LIMIT,
+} from '../utils/const-variables/api'
+import { onGetLeaderboard } from '../store/thunks/leaderboard-thunk'
 
 export interface IRoute {
   path: RoutesEnum | string
@@ -144,8 +148,24 @@ export const routes: IRoute[] = [
       {
         path: RoutesEnum.LEADERBOARD,
         element: <Leaderboard />,
-        loader: (dispatch: AppDispatch) => {
-          return [dispatch(onGetUser())]
+        loader: (
+          dispatch: AppDispatch,
+          pathname: string,
+          searchParams: Record<string, unknown>
+        ) => {
+          const page = searchParams[PAGE_QUERY]
+          let intPage = parseInt(page as string)
+          if (isNaN(intPage)) {
+            intPage = 1
+          }
+          const offset = (intPage - 1) * LEADERBOARD_LOAD_LIMIT
+
+          return [
+            dispatch(onGetUser()),
+            dispatch(
+              onGetLeaderboard({ limit: LEADERBOARD_LOAD_LIMIT, offset })
+            ),
+          ]
         },
       },
       {

--- a/packages/client/src/store/repositories/LeaderboardRepository.ts
+++ b/packages/client/src/store/repositories/LeaderboardRepository.ts
@@ -1,0 +1,13 @@
+import { Leaderboard } from '../../utils/types/leaderboard'
+import { getLeaderboard } from '../../utils/rest-api/leaderboard-api'
+import { BaseGetAllItemsQuery } from '../../utils/types/base-query'
+
+export interface ILeaderboardRepository {
+  getLeaderboard(query: BaseGetAllItemsQuery): Promise<Leaderboard>
+}
+
+export class LeaderboardRepository implements ILeaderboardRepository {
+  async getLeaderboard(query: BaseGetAllItemsQuery): Promise<Leaderboard> {
+    return await getLeaderboard(query)
+  }
+}

--- a/packages/client/src/store/services/LeaderboadService.ts
+++ b/packages/client/src/store/services/LeaderboadService.ts
@@ -1,0 +1,15 @@
+import { Leaderboard } from '../../utils/types/leaderboard'
+import { ILeaderboardRepository } from '../repositories/LeaderboardRepository'
+import { BaseGetAllItemsQuery } from '../../utils/types/base-query'
+
+export interface ILeaderboardService {
+  getLeaderboard(query: BaseGetAllItemsQuery): Promise<Leaderboard>
+}
+
+export class LeaderboardService implements ILeaderboardService {
+  constructor(private _repo: ILeaderboardRepository) {}
+
+  async getLeaderboard(query: BaseGetAllItemsQuery) {
+    return this._repo.getLeaderboard(query)
+  }
+}

--- a/packages/client/src/store/services/ThunkService.ts
+++ b/packages/client/src/store/services/ThunkService.ts
@@ -1,17 +1,25 @@
 import { IUserService } from './UserService'
 import { IForumService } from './ForumService'
+import { ILeaderboardService } from './LeaderboadService'
 
 export interface IThunkService {
   userService: IUserService
   forumService: IForumService
+  leaderboardService: ILeaderboardService
 }
 
 export class ThunkService implements IThunkService {
   userService: IUserService
   forumService: IForumService
+  leaderboardService: ILeaderboardService
 
-  constructor(userService: IUserService, forumService: IForumService) {
+  constructor(
+    userService: IUserService,
+    forumService: IForumService,
+    leaderboardService: ILeaderboardService
+  ) {
     this.userService = userService
     this.forumService = forumService
+    this.leaderboardService = leaderboardService
   }
 }

--- a/packages/client/src/store/slices/forum-slice.ts
+++ b/packages/client/src/store/slices/forum-slice.ts
@@ -278,7 +278,7 @@ const forumSlice = createSlice({
         const id = action.meta.arg.categoryId
         state.topicInfo.topics[id].isLoading = false
         state.topicInfo.topics[id].errorMessage = null
-        state.topicInfo.topics[id].topicItems = !action.meta.arg.offset
+        state.topicInfo.topics[id].topicItems = !action.meta.arg.updatedAt
           ? action.payload
           : (state.topicInfo.topics[id].topicItems || []).concat(action.payload)
       })

--- a/packages/client/src/store/thunks/leaderboard-thunk.ts
+++ b/packages/client/src/store/thunks/leaderboard-thunk.ts
@@ -1,12 +1,10 @@
 import { createAsyncThunk } from '@reduxjs/toolkit'
-import {
-  getLeaderboard,
-  updateScore,
-} from '../../utils/rest-api/leaderboard-api'
+import { updateScore } from '../../utils/rest-api/leaderboard-api'
 import { RootState } from '../store'
 import { BaseGetAllItemsQuery } from '../../utils/types/base-query'
 import { Leaderboard } from '../../utils/types/leaderboard'
 import { UserScore } from '../../utils/types/user'
+import { IThunkService } from '../services/ThunkService'
 
 export const onGetLeaderboard = createAsyncThunk<
   Leaderboard,
@@ -14,11 +12,12 @@ export const onGetLeaderboard = createAsyncThunk<
   { rejectValue: string }
 >(
   'leaderboard/onGetLeaderboard',
-  async (query, { rejectWithValue }) => {
+  async (query, thunkAPI) => {
     try {
-      return await getLeaderboard(query)
+      const service = thunkAPI.extra as IThunkService
+      return await service.leaderboardService.getLeaderboard(query)
     } catch (err: unknown) {
-      return rejectWithValue(
+      return thunkAPI.rejectWithValue(
         (err as Error).message || 'Unable to get leaderboard items'
       )
     }

--- a/packages/client/src/utils/rest-api/forum-api.ts
+++ b/packages/client/src/utils/rest-api/forum-api.ts
@@ -58,14 +58,14 @@ export async function getForumTopics(
 ): Promise<IForumTopic[]> {
   const {
     categoryId,
-    offset = 0,
+    updatedAt,
     limit = TOPICS_LOAD_LIMIT,
     search = '',
   } = topicsQuery
   return await request(
     BASE_SERVER_URL,
     `${FORUM_CATEGORIES_API_URL}/${categoryId}${FORUM_TOPICS_API_URL}${stringifyQuery(
-      { limit, offset, search }
+      { limit, updatedAt, search }
     )}`,
     {
       method: FetchMethods.GET,

--- a/packages/client/src/utils/types/forum.ts
+++ b/packages/client/src/utils/types/forum.ts
@@ -17,7 +17,8 @@ export interface IForumTopic {
   id: number
   name: string
   categoryId: number
-  createdAt: string
+  createdAt: number
+  updatedAt: number
   userId: number
 }
 
@@ -27,6 +28,7 @@ interface IGetForumItemsBaseQuery extends BaseGetAllItemsQuery {
 
 export interface IGetForumTopicsQuery extends IGetForumItemsBaseQuery {
   categoryId: number
+  updatedAt?: number
 }
 
 export interface IGetForumCommentsQuery extends IGetForumItemsBaseQuery {
@@ -48,7 +50,7 @@ export interface IAddForumCommentQuery {
 
 export interface IForumComment extends IAddForumCommentQuery {
   id: number
-  createdAt: string
+  createdAt: number
   replyCount: number
 }
 

--- a/packages/client/ssr.tsx
+++ b/packages/client/ssr.tsx
@@ -14,6 +14,8 @@ import { createStore } from './src/store/store'
 import { ForumService } from './src/store/services/ForumService'
 import { IForumRepository } from './src/store/repositories/ForumRepository'
 import { PayloadAction } from '@reduxjs/toolkit'
+import { ILeaderboardRepository } from './src/store/repositories/LeaderboardRepository'
+import { LeaderboardService } from './src/store/services/LeaderboadService'
 
 const findRoute = (pathname: string, routes: IRoute[]) => {
   for (let i = 0; i < routes.length; i++) {
@@ -32,11 +34,13 @@ const findRoute = (pathname: string, routes: IRoute[]) => {
 export async function render(
   url: string,
   userRepository: IUserRepository,
-  forumRepository: IForumRepository
+  forumRepository: IForumRepository,
+  leaderboardRepository: ILeaderboardRepository
 ) {
   const service = new ThunkService(
     new UserService(userRepository),
-    new ForumService(forumRepository)
+    new ForumService(forumRepository),
+    new LeaderboardService(leaderboardRepository)
   )
   const store = createStore(service)
 

--- a/packages/server/index.ts
+++ b/packages/server/index.ts
@@ -32,6 +32,7 @@ import {
 } from './src/utils/start-server-helper'
 import { ThunkUserRepository } from './src/repositories/ThunkUserRepository'
 import { ThunkForumRepository } from './src/repositories/ThunkForumRepository'
+import { ThunkLeaderboardRepository } from './src/repositories/ThunkLeaderboardRepository'
 import serialize from 'serialize-javascript'
 
 async function startServer() {
@@ -83,7 +84,8 @@ async function startServer() {
       const [initialState, appHtml] = await render(
         url,
         new ThunkUserRepository(req.headers.cookie),
-        new ThunkForumRepository(req.headers.cookie)
+        new ThunkForumRepository(req.headers.cookie),
+        new ThunkLeaderboardRepository(req.headers.cookie)
       )
 
       const preloadedState = `<script>window.__PRELOADED_STATE__=${serialize(

--- a/packages/server/src/controllers/TopicController.ts
+++ b/packages/server/src/controllers/TopicController.ts
@@ -7,14 +7,19 @@ export class TopicController {
   async findAll(req: Request, res: Response) {
     try {
       const categoryId = parseInt(req.params['id'])
-      const { limit, offset } = getQueryLimitAndOffset(req)
+      const { limit } = getQueryLimitAndOffset(req)
       const search =
         typeof req.query['search'] === 'string' ? req.query['search'] : ''
+      const updatedAt =
+        typeof req.query['updatedAt'] === 'string' &&
+        req.query['updatedAt'].length > 0
+          ? parseInt(req.query['updatedAt'])
+          : undefined
 
       const topics = await topicService.findAll(
         categoryId,
         limit,
-        offset,
+        updatedAt,
         search
       )
       return res.status(200).json(topics)

--- a/packages/server/src/repositories/ThunkForumRepository.ts
+++ b/packages/server/src/repositories/ThunkForumRepository.ts
@@ -32,8 +32,8 @@ export class ThunkForumRepository implements IThunkForumRepository {
     const userOrErr = await this.thunkUserRepository.getCurrentUser()
 
     if (!instanceOfApiError(userOrErr)) {
-      const { categoryId, limit, offset, search } = topicsQuery
-      return await topicService.findAll(categoryId, limit, offset, search)
+      const { categoryId, limit, updatedAt, search } = topicsQuery
+      return await topicService.findAll(categoryId, limit, updatedAt, search)
     }
     return []
   }

--- a/packages/server/src/repositories/ThunkLeaderboardRepository.ts
+++ b/packages/server/src/repositories/ThunkLeaderboardRepository.ts
@@ -1,0 +1,30 @@
+import type { Leaderboard } from '../utils/types/user'
+import { leaderboardService } from '../services/LeaderboardService'
+import type { QueryClause } from '../utils/types/query'
+import { instanceOfApiError } from '../utils/types/api'
+import { ThunkUserRepository } from './ThunkUserRepository'
+
+interface IThunkLeaderboardRepository {
+  getLeaderboard(query: QueryClause): Promise<Leaderboard>
+}
+
+export class ThunkLeaderboardRepository implements IThunkLeaderboardRepository {
+  thunkUserRepository
+
+  constructor(private _cookie?: string) {
+    this.thunkUserRepository = new ThunkUserRepository(this._cookie)
+  }
+
+  async getLeaderboard(query: QueryClause) {
+    const userOrErr = await this.thunkUserRepository.getCurrentUser()
+
+    if (!instanceOfApiError(userOrErr)) {
+      return await leaderboardService.findAll(
+        this._cookie,
+        query.limit,
+        query.offset
+      )
+    }
+    return { players: [], total: 0 }
+  }
+}

--- a/packages/server/src/services/TopicService.ts
+++ b/packages/server/src/services/TopicService.ts
@@ -25,10 +25,15 @@ export class TopicService {
   async findAll(
     id: number,
     limit?: number,
-    offset?: number,
+    updatedAt?: number,
     search?: string
   ): Promise<TopicDTO[]> {
-    const topics = await this._topicRepository.getAll(id, limit, offset, search)
+    const topics = await this._topicRepository.getAll(
+      id,
+      limit,
+      updatedAt,
+      search
+    )
     return topics.map(topic => getTopicDTOFromModel(topic))
   }
 

--- a/packages/server/src/utils/types/dto.ts
+++ b/packages/server/src/utils/types/dto.ts
@@ -3,8 +3,8 @@ import type { CommentModel } from '../../models/CommentModel'
 import type { CategoryModel } from '../../models/CategoryModel'
 
 interface Timestamp {
-  createdAt: string
-  updatedAt: string
+  createdAt: number
+  updatedAt: number
 }
 
 export interface CategoryDTO extends Timestamp {
@@ -19,8 +19,8 @@ export const getCategoryDTOFromModel = (model: CategoryModel): CategoryDTO => {
     id,
     name,
     topicCount,
-    createdAt: createdAt.toString(),
-    updatedAt: updatedAt.toString(),
+    createdAt: createdAt.getTime(),
+    updatedAt: updatedAt.getTime(),
   }
 }
 
@@ -38,8 +38,8 @@ export const getTopicDTOFromModel = (model: TopicModel): TopicDTO => {
     name,
     categoryId,
     userId,
-    createdAt: createdAt.toString(),
-    updatedAt: updatedAt.toString(),
+    createdAt: createdAt.getTime(),
+    updatedAt: updatedAt.getTime(),
   }
 }
 
@@ -81,8 +81,8 @@ export const getCommentDTOFromModel = (
     parentCommentId,
     topicId,
     userId,
-    createdAt: createdAt.toString(),
-    updatedAt: updatedAt.toString(),
+    createdAt: createdAt.getTime(),
+    updatedAt: updatedAt.getTime(),
     replyCount,
   }
 }

--- a/packages/server/src/utils/types/query.ts
+++ b/packages/server/src/utils/types/query.ts
@@ -1,4 +1,4 @@
-interface QueryClause {
+export interface QueryClause {
   offset?: number
   limit?: number
 }

--- a/packages/server/src/utils/types/query.ts
+++ b/packages/server/src/utils/types/query.ts
@@ -6,6 +6,7 @@ interface QueryClause {
 export interface ForumTopicsQuery extends QueryClause {
   categoryId: number
   search?: string
+  updatedAt?: number
 }
 
 export interface ForumCommentsQuery extends QueryClause {

--- a/packages/server/src/utils/validation-schemas.ts
+++ b/packages/server/src/utils/validation-schemas.ts
@@ -58,10 +58,13 @@ export const getTopicsValidationSchema = Yup.object()
   .shape({
     query: Yup.object().shape({
       [ForumFieldsEnum.LIMIT]: limitValidation,
-      [ForumFieldsEnum.OFFSET]: offsetValidation,
       [ForumFieldsEnum.SEARCH]: Yup.string()
         .optional()
         .typeError('Некорректное условие поиска'),
+      updatedAt: Yup.number()
+        .positive()
+        .optional()
+        .typeError('Некорректное значение updatedAt'),
     }),
   })
   .concat(idParamsValidationSchema)

--- a/packages/server/swagger.json
+++ b/packages/server/swagger.json
@@ -386,9 +386,9 @@
             }
           },
           {
-            "name": "offset",
+            "name": "updatedAt",
             "in": "query",
-            "description": "number of items to skip before returning them",
+            "description": "updatedAt timestamp of last received item",
             "required": false,
             "schema": {
               "type": "integer",
@@ -1296,8 +1296,8 @@
         "type": "object",
         "properties": {
           "createdAt": {
-            "type": "string",
-            "example": "2023-04-24T09:46:59.905Z"
+            "type": "number",
+            "example": 1685793868260
           }
         }
       },
@@ -1308,8 +1308,8 @@
         "type": "object",
         "properties": {
           "updatedAt": {
-            "type": "string",
-            "example": "2023-04-24T09:46:59.905Z"
+            "type": "number",
+            "example": 1685793868260
           }
         }
       },


### PR DESCRIPTION
### Какую задачу решаем
[Научиться пересоздавать клиентское Redux-хранилище из серверного](https://linear.app/kvas/issue/KVA-42/nauchitsya-peresozdavat-klientskoe-redux-hranilishe-iz-servernogo)

- Добавлено начальное состояние (preloaded state) для лидерборда.
-  Для страницы со списком топиков изменен параметр запроса (`offset` заменен на `updatedAt` последнего полученного топика), т.к. возникала ошибка при добавлении нового топика во время скролла.

### Скриншоты/видяшка (если есть)

### TBD (если есть)